### PR TITLE
Add new EncodeM API

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,21 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1
 
+    - name: Install Yaml
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install yasm
+
+    - name: Build isa-l
+      run: |
+        git clone --depth 1 --branch v2.28.0 https://github.com/intel/isa-l.git
+        cd isa-l
+        ./autogen.sh
+        ./configure --prefix=/usr
+        make
+        sudo make install
+        sudo ldconfig
+
     - name: Build liberasurecode
       run: |
         git clone https://github.com/openstack/liberasurecode.git

--- a/backend.go
+++ b/backend.go
@@ -10,7 +10,6 @@ package erasurecode
 char ** makeStrArray(int n) { return calloc(n, sizeof (char *)); }
 void freeStrArray(char ** arr) { free(arr); }
 void * getStrArrayItem(char ** arr, int idx) { return arr[idx]; }
-char * getStrOffset(char *ptr, int offset) { return ptr + offset; }
 void setStrArrayItem(char ** arr, int idx, unsigned char * val) { arr[idx] = (char *) val; }
 // shims because the fragment headers use misaligned fields
 uint64_t getOrigDataSize(struct fragment_header_s *header) { return header->meta.orig_data_size; }
@@ -498,8 +497,9 @@ func (backend *Backend) DecodeMatrix(frags [][]byte, piecesize int) (*DecodeData
 			// try to decode fastly (if we have all data fragments), providing the good offset of the
 			// linearized buffer, according the block number we are decoding
 			var outlen C.uint64_t
+			var ptr uintptr = uintptr(unsafe.Pointer(data)) + uintptr(blockNr*piecesize*backend.K)
 			p := C.decode_fast(C.int(backend.K), cFrags, C.int(len(frags)),
-				C.getStrOffset(data, C.int(blockNr*piecesize*backend.K)),
+				(*C.char)(unsafe.Pointer(ptr)),
 				C.ulong(piecesize*backend.K), &outlen)
 
 			if p == nil {

--- a/backend.go
+++ b/backend.go
@@ -554,7 +554,24 @@ func (backend *Backend) decodeMatrixSlow(frags [][]byte, piecesize int) (*Decode
 		data = append(data, subdata.Data...)
 		subdata.Free()
 	}
-	return &DecodeData{data, nil}, nil
+	return &DecodeData{data, func(){}}, nil
+}
+
+// GetRangeMatrix returns the bounds of each data fragments to get to satisfy
+// {start, end} range
+func (backend *Backend) GetRangeMatrix(start, end, chunksize int) (int, int) {
+	blockSize := chunksize
+	groupSize := blockSize * backend.K
+
+	// start's block number
+	rStart := start / groupSize
+	rEnd   := end / groupSize
+
+	// convert block number to offset
+	rStart = rStart * (chunksize + backend.GetHeaderSize())
+	rEnd = (rEnd + 1) * (chunksize + backend.GetHeaderSize())
+
+	return rStart, rEnd
 }
 
 // Decode is the general purpose decoding function (without sub-chunking)

--- a/backend.go
+++ b/backend.go
@@ -559,9 +559,10 @@ func (backend *Backend) decodeMatrixSlow(frags [][]byte, piecesize int) (*Decode
 
 // GetRangeMatrix returns the bounds of each data fragments to get to satisfy
 // {start, end} range
-func (backend *Backend) GetRangeMatrix(start, end, chunksize int) (int, int) {
+func (backend *Backend) GetRangeMatrix(start, end, chunksize, fragSize int) (int, int) {
 	blockSize := chunksize
 	groupSize := blockSize * backend.K
+	maxBound := fragSize / backend.K
 
 	// start's block number
 	rStart := start / groupSize
@@ -570,7 +571,12 @@ func (backend *Backend) GetRangeMatrix(start, end, chunksize int) (int, int) {
 	// convert block number to offset
 	rStart = rStart * (chunksize + backend.headerSize)
 	rEnd = (rEnd + 1) * (chunksize + backend.headerSize)
-
+	if rStart > maxBound {
+		rStart = maxBound
+	}
+	if rEnd > maxBound {
+		rEnd = maxBound
+	}
 	return rStart, rEnd
 }
 

--- a/backend.go
+++ b/backend.go
@@ -80,7 +80,7 @@ int encode_chunk(int desc, char *data, int datalen, struct encode_chunk_context 
     return -1;
   }
 
-
+  int tot_len_sum = 0;
   for (i = 0; i < ctx->k; i++) {
     char *ptr = &ctx->datas[i][nth * one_cell_size];
     fragment_header_t *hdr = (fragment_header_t*)ptr;
@@ -90,7 +90,8 @@ int encode_chunk(int desc, char *data, int datalen, struct encode_chunk_context 
           int len_to_copy = ctx->chunk_size;
           if (len_to_copy > dataend - dataoffset) {
                   len_to_copy = dataend - dataoffset;
-          }
+		  }
+		  tot_len_sum += len_to_copy;
           memcpy(ptr, dataoffset, len_to_copy);
         }
         dataoffset += ctx->chunk_size;
@@ -110,7 +111,7 @@ int encode_chunk(int desc, char *data, int datalen, struct encode_chunk_context 
       fprintf(stderr, "error encode ret = %d\n", ret);
       return -1;
   } else {
-    ret = finalize_fragments_after_encode(ec, ctx->k, ctx->m, ctx->chunk_size, ctx->chunk_size, k_ref, m_ref);
+    ret = finalize_fragments_after_encode(ec, ctx->k, ctx->m, ctx->chunk_size, tot_len_sum, k_ref, m_ref);
     if (ret < 0) {
       fprintf(stderr, "error encode ret = %d\n", ret);
       return -1;

--- a/backend.go
+++ b/backend.go
@@ -30,6 +30,14 @@ struct encode_chunk_context {
   int m;
 };
 
+// instead of encoding K blocks of data, we divide and subencode blocks of
+// 'piecesize' bytes.
+// desc  : liberasurecode handle
+// data : the whole data to encode
+// datalen : the datalen
+// piecesize : the size of little blocks used for encoding
+// ctx : contains informations such as the ECN schema (see below)
+//
 void encode_chunk_prepare(int desc,
                           char *data,
                           int datalen,
@@ -41,6 +49,7 @@ void encode_chunk_prepare(int desc,
   const int k = ctx->instance->args.uargs.k;
   const int m = ctx->instance->args.uargs.m;
 
+  // here we compute the number of (k) subgroup of 'piecesize' bytes we can create
   int block_size = piecesize * k;
   ctx->number_of_subgroup = datalen / block_size;
   if(ctx->number_of_subgroup * block_size != datalen) {
@@ -281,6 +290,12 @@ func (backend *Backend) Encode(data []byte) (*EncodeData, error) {
 		C.liberasurecode_encode_cleanup(
 			backend.libecDesc, dataFrags, parityFrags)
 	}}, nil
+}
+
+// GetHeaderSize returns the size of the header written by liberasurecode before each chunks
+func (backend *Backend) GetHeaderSize() int {
+	r := int(C.getHeaderSize())
+	return r
 }
 
 // EncodeMatrix encodes data in small subpart of chunkSize bytes

--- a/backend.go
+++ b/backend.go
@@ -536,14 +536,14 @@ func (backend *Backend) decodeMatrixSlow(frags [][]byte, piecesize int) (*Decode
 	if blockNr*blockSize != fragLen {
 		blockNr++
 	}
-	data := make([]byte, 0)
+	data := make([]byte, 0, blockNr*piecesize*backend.K)
 
 	cellSize := piecesize + backend.headerSize
 
 	for i := 0; i < blockNr; i++ {
-		var vect [][]byte
+		vect := make([][]byte, len(frags))
 		for j := 0; j < len(frags); j++ {
-			vect = append(vect, frags[j][i*cellSize:(i+1)*cellSize])
+			vect[j] = frags[j][i*cellSize:(i+1)*cellSize]
 		}
 		subdata, err := backend.Decode(vect)
 		if err != nil {
@@ -688,7 +688,6 @@ func (backend *Backend) ReconstructMatrix(frags [][]byte, fragIndex int, chunksi
 		vect := make([][]byte, len(frags))
 		for j := 0; j < len(frags); j++ {
 			vect[j] = frags[j][i*cellSize:(i+1)*cellSize]
-			//vect = append(vect, frags[j][i*cellSize:(i+1)*cellSize])
 		}
 		if err := backend.reconstruct(vect, fragIndex, data[i * blockSize:]) ; err != nil {
 			return nil, fmt.Errorf("error subdecoding %d cause =%v", i, err)

--- a/backend.go
+++ b/backend.go
@@ -5,6 +5,7 @@ package erasurecode
 #include <stdlib.h>
 #include <liberasurecode/erasurecode.h>
 #include <liberasurecode/erasurecode_helpers_ext.h>
+#include <liberasurecode/erasurecode_postprocessing.h>
 // shims to make working with frag arrays easier
 char ** makeStrArray(int n) { return calloc(n, sizeof (char *)); }
 void freeStrArray(char ** arr) { free(arr); }
@@ -15,6 +16,110 @@ uint64_t getOrigDataSize(struct fragment_header_s *header) { return header->meta
 uint32_t getBackendVersion(struct fragment_header_s *header) { return header->meta.backend_version; }
 ec_backend_id_t getBackendID(struct fragment_header_s *header) { return header->meta.backend_id; }
 uint32_t getECVersion(struct fragment_header_s *header) { return header->libec_version; }
+int getHeaderSize() { return sizeof(struct fragment_header_s); }
+
+struct encode_chunk_context {
+  ec_backend_t instance; // backend instance
+  char **datas;                  // the K datas
+  char **codings;        // the M codings
+  unsigned int number_of_subgroup; // number of subchunk in each K part
+  unsigned int chunk_size;       // datasize of each subchunk
+  unsigned int frags_len; // allocating size of each K+M objects
+  int blocksize;          // k-bounds of data
+  int k;
+  int m;
+};
+
+void encode_chunk_prepare(int desc,
+                          char *data,
+                          int datalen,
+                          int piecesize,
+                          struct encode_chunk_context *ctx)
+{
+  ctx->instance = liberasurecode_backend_instance_get_by_desc(desc);
+  int i;
+  const int k = ctx->instance->args.uargs.k;
+  const int m = ctx->instance->args.uargs.m;
+
+  int block_size = piecesize * k;
+  ctx->number_of_subgroup = datalen / block_size;
+  if(ctx->number_of_subgroup * block_size != datalen) {
+        ctx->number_of_subgroup++;
+  }
+
+  ctx->chunk_size = piecesize;
+
+  ctx->k = k;
+  ctx->m = m;
+
+  ctx->datas     = calloc(ctx->k, sizeof(char*));
+  ctx->codings   = calloc(ctx->m, sizeof(char*));
+  ctx->frags_len = (sizeof(fragment_header_t) + piecesize) * ctx->number_of_subgroup;
+
+  for (i = 0; i < ctx->k; ++i) {
+    ctx->datas[i] = get_aligned_buffer16(ctx->frags_len);
+  }
+
+  for (i = 0; i < ctx->m; ++i) {
+    ctx->codings[i] = get_aligned_buffer16(ctx->frags_len);
+  }
+
+}
+
+int encode_chunk(int desc, char *data, int datalen, struct encode_chunk_context *ctx, int nth)
+{
+  ec_backend_t ec = ctx->instance;
+  char *k_ref[ctx->k];
+  char *m_ref[ctx->m];
+
+  int one_cell_size = sizeof(fragment_header_t) + ctx->chunk_size;
+  int i, ret;
+  char const *const dataend = data + datalen;
+  char *dataoffset = data + (ctx->k * nth) * ctx->chunk_size;
+  if (nth >= ctx->number_of_subgroup) {
+    return -1;
+  }
+
+
+  for (i = 0; i < ctx->k; i++) {
+    char *ptr = &ctx->datas[i][nth * one_cell_size];
+    fragment_header_t *hdr = (fragment_header_t*)ptr;
+    hdr->magic = LIBERASURECODE_FRAG_HEADER_MAGIC;
+        ptr = (char*) (hdr + 1);
+        if(dataoffset < dataend) {
+          int len_to_copy = ctx->chunk_size;
+          if (len_to_copy > dataend - dataoffset) {
+                  len_to_copy = dataend - dataoffset;
+          }
+          memcpy(ptr, dataoffset, len_to_copy);
+        }
+        dataoffset += ctx->chunk_size;
+    k_ref[i] = ptr;
+  }
+
+  for (i = 0; i < ctx->m; i++) {
+    char *ptr = &ctx->codings[i][nth * one_cell_size];
+    fragment_header_t *hdr = (fragment_header_t*)ptr;
+    hdr->magic = LIBERASURECODE_FRAG_HEADER_MAGIC;
+    ptr = (char*) (hdr + 1);
+    m_ref[i] = ptr;
+  }
+
+  ret = ec->common.ops->encode(ec->desc.backend_desc, k_ref, m_ref, ctx->chunk_size);
+  if (ret < 0) {
+      fprintf(stderr, "error encode ret = %d\n", ret);
+      return -1;
+  } else {
+    ret = finalize_fragments_after_encode(ec, ctx->k, ctx->m, ctx->chunk_size, ctx->chunk_size, k_ref, m_ref);
+    if (ret < 0) {
+      fprintf(stderr, "error encode ret = %d\n", ret);
+      return -1;
+    }
+  }
+  return 0;
+}
+
+
 */
 import "C"
 
@@ -24,6 +129,8 @@ import (
 	"fmt"
 	"runtime"
 	"unsafe"
+	"sync"
+	"sync/atomic"
 )
 
 type Version struct {
@@ -174,6 +281,53 @@ func (backend *Backend) Encode(data []byte) (*EncodeData, error) {
 			backend.libecDesc, dataFrags, parityFrags)
 	}}, nil
 }
+
+// EncodeMatrix encodes data in small subpart of chunkSize bytes
+func (backend *Backend) EncodeMatrix(data []byte, chunkSize int) (*EncodeData, error) {
+	var wg sync.WaitGroup
+	var ctx C.struct_encode_chunk_context
+	pData := (*C.char)(unsafe.Pointer(&data[0]))
+	pDataLen := C.int(len(data))
+	cChunkSize := C.int(chunkSize)
+
+	C.encode_chunk_prepare(backend.libecDesc, pData, pDataLen, cChunkSize, &ctx)
+
+	wg.Add(int(ctx.number_of_subgroup))
+	var errCounter uint64
+	for i := 0; i < int(ctx.number_of_subgroup); i++ {
+			go func(nth int) {
+					defer wg.Done()
+					r := C.encode_chunk(backend.libecDesc, pData, pDataLen, &ctx, C.int(nth))
+					if r < 0 {
+							atomic.AddUint64(&errCounter, 1)
+					}
+			}(i)
+	}
+	wg.Wait()
+
+	if errCounter != 0 {
+			return &EncodeData{nil, func() {
+					C.liberasurecode_encode_cleanup(
+							backend.libecDesc, ctx.datas, ctx.codings) }},
+					fmt.Errorf("error encoding chunk (%+v encoding failed)", errCounter)
+	}
+	result := make([][]byte, backend.K+backend.M)
+	fragLen := ctx.frags_len
+	for i := 0; i < backend.K; i++ {
+			result[i] = (*[1 << 30]byte)(unsafe.Pointer(C.getStrArrayItem(ctx.datas, C.int(i))))[:int(C.int(fragLen)):int(C.int(fragLen))]
+
+	}
+	for i := 0; i < backend.M; i++ {
+			result[i+backend.K] = (*[1 << 30]byte)(unsafe.Pointer(C.getStrArrayItem(ctx.codings, C.int(i))))[:int(C.int(fragLen)):int(C.int(fragLen))]
+	}
+
+
+	return &EncodeData{result, func() {
+			C.liberasurecode_encode_cleanup(
+					backend.libecDesc, ctx.datas, ctx.codings)
+	}}, nil
+}
+
 
 type DecodeData struct {
 	Data []byte

--- a/backend_test.go
+++ b/backend_test.go
@@ -538,6 +538,7 @@ func BenchmarkEncode(b *testing.B) {
 }
 
 const DefaultChunkSize = 32768
+const DefaultFragSize = 1048576
 
 func BenchmarkDecodeM(b *testing.B) {
 	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
@@ -711,7 +712,7 @@ func checkData(data []byte) bool {
 }
 
 func TestMatrixBounds(t *testing.T) {
-	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: 3, M: 1, W: 8, HD: 5})
+	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: 2, M: 1, W: 8, HD: 5})
 
 	if err != nil {
 		t.Fatalf("cannot init backend: (%v)", err)
@@ -724,17 +725,14 @@ func TestMatrixBounds(t *testing.T) {
 		expectedStart int
 		expectedEnd   int
 	}{
-		{rangeStart: 0, rangeEnd: 95, chunkUnit: 32, expectedStart: 0, expectedEnd: 112},
-		{rangeStart: 10, rangeEnd: 97, chunkUnit: 32, expectedStart: 0, expectedEnd: 224},
-		{rangeStart: 97, rangeEnd: 98, chunkUnit: 32, expectedStart: 112, expectedEnd: 224},
-		{rangeStart: 0, rangeEnd: 32*backend.K*2 + 2, chunkUnit: 32, expectedStart: 0, expectedEnd: 336},
+		{rangeStart: 1023999, rangeEnd: 1048575, chunkUnit: DefaultChunkSize, expectedStart: 492720, expectedEnd: 524288},
 	}
 
 	for _, param := range testParams {
 		p := param
 		testName := fmt.Sprintf("TestEMatrixBounds-%d-%d", p.rangeStart, p.rangeEnd)
 		t.Run(testName, func(t *testing.T) {
-			start, end := backend.GetRangeMatrix(p.rangeStart, p.rangeEnd, p.chunkUnit)
+			start, end := backend.GetRangeMatrix(p.rangeStart, p.rangeEnd, p.chunkUnit, DefaultFragSize)
 			if start != p.expectedStart || end != p.expectedEnd {
 				t.Errorf("start is %d instead of %d and end is %d instead of %d",
 					start, p.expectedStart, end, p.expectedEnd)

--- a/backend_test.go
+++ b/backend_test.go
@@ -535,6 +535,61 @@ func BenchmarkEncode(b *testing.B) {
 	}
 }
 
+const DefaultChunkSize = 32768
+
+func BenchmarkDecodeM(b *testing.B) {
+	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
+
+	buf := bytes.Repeat([]byte("A"), 1024*1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoded, err := backend.EncodeMatrix(buf, DefaultChunkSize)
+
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer encoded.Free()
+
+		decoded, err := backend.DecodeMatrix(encoded.Data, DefaultChunkSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if decoded != nil {
+			if decoded.Free != nil {
+				decoded.Free()
+			}
+		} else {
+			b.Fatal("decoded is nil")
+		}
+	}
+}
+
+func BenchmarkDecodeMSlow(b *testing.B) {
+	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
+	buf := bytes.Repeat([]byte("A"), 1024*1024)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoded, err := backend.EncodeMatrix(buf, DefaultChunkSize)
+
+		if err != nil {
+			b.Fatal(err)
+		}
+		defer encoded.Free()
+
+		decoded, err := backend.decodeMatrixSlow(encoded.Data, DefaultChunkSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if decoded != nil {
+			if decoded.Free != nil {
+				decoded.Free()
+			}
+		} else {
+			b.Fatal("decoded is nil")
+		}
+	}
+}
+
 func BenchmarkEncodeM(b *testing.B) {
 	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
 

--- a/backend_test.go
+++ b/backend_test.go
@@ -568,6 +568,27 @@ func BenchmarkDecodeM(b *testing.B) {
 	backend.Close()
 }
 
+func BenchmarkReconstructM(b *testing.B) {
+	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
+
+	buf := bytes.Repeat([]byte("A"), 1024*1024)
+	encoded, err := backend.EncodeMatrix(buf, DefaultChunkSize)
+
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer encoded.Free()
+	flags := encoded.Data[1:]
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := backend.ReconstructMatrix(flags, 0, DefaultChunkSize)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	backend.Close()
+}
+
 func BenchmarkDecodeMSlow(b *testing.B) {
 	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
 	buf := bytes.Repeat([]byte("A"), 1024*1024)

--- a/backend_test.go
+++ b/backend_test.go
@@ -636,12 +636,15 @@ func TestEncodeM(t *testing.T) {
 		buf[i] = byte(65 + i%26)
 	}
 
+	// All our sub tests case. Each {X,Y} represents respecitvely the chunking unit (size of each subpart)
+	// and the data we want to read when we decode
 	testParams := [][]int{{4096, 4097}, {4097, 4096}, {4096, len(buf)}, {4096, 4096}}
 
 	for _, param := range testParams {
 		p := param
 		testName := fmt.Sprintf("TestEncodeB-%d-%d", p[0], p[1])
 		t.Run(testName, func(t *testing.T) {
+			// Do the matrix encoding
 			result, err := backend.EncodeMatrix(buf, p[0])
 
 			defer result.Free()
@@ -650,6 +653,9 @@ func TestEncodeM(t *testing.T) {
 				t.Errorf("failed to encode %+v", err)
 			}
 
+			// Do the matrix decoding. It should work fastly because we have
+			// all data fragments. After, we check that our linearized buffer
+			// contains expected data
 			ddata, err := backend.DecodeMatrix(result.Data, p[0])
 			if ok := checkData(ddata.Data); ok == false {
 				t.Errorf("bad matrix decoding")
@@ -682,6 +688,7 @@ func TestEncodeM(t *testing.T) {
 	}
 }
 
+// checkData reads a buffer and check that we have a round robin sequence of [A-Z] characters
 func checkData(data []byte) bool {
 	for i := 0; i < len(data)-1; i++ {
 		if data[i] != 'Z' {

--- a/backend_test.go
+++ b/backend_test.go
@@ -535,7 +535,7 @@ func BenchmarkEncode(b *testing.B) {
 }
 
 func BenchmarkEncodeM(b *testing.B) {
-	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 5, M: 1, W: 8, HD: 5})
+	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
 
 	buf := bytes.Repeat([]byte("A"), 1024*1024)
 
@@ -550,7 +550,7 @@ func BenchmarkEncodeM(b *testing.B) {
 }
 
 func BenchmarkDecode(b *testing.B) {
-	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 5, M: 1, W: 8, HD: 5})
+	backend, _ := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
 
 	buf := bytes.Repeat([]byte("A"), 1024*1024)
 	res, _ := backend.Encode(buf)
@@ -568,7 +568,7 @@ func BenchmarkDecode(b *testing.B) {
 }
 
 func TestEncodeM(t *testing.T) {
-	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 1, W: 8, HD: 5})
+	backend, err := InitBackend(Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5})
 
 	if err != nil {
 		t.Fatalf("cannot init backend: (%v)", err)
@@ -578,7 +578,7 @@ func TestEncodeM(t *testing.T) {
 	for i := 0; i < len(buf); i++ {
 		buf[i] = byte(65 + i%26)
 	}
-	result, err := backend.EncodeMatrix(buf, 4096)
+	result, err := backend.EncodeMatrix(buf, 4097)
 
 	defer result.Free()
 
@@ -587,47 +587,45 @@ func TestEncodeM(t *testing.T) {
 	}
 
 	/* now we will decode the first 80000bytes */
-	getRange := 80000
-	blockSize := (4096 + 80) * backend.K
+	getRange := 1024 * 1024
+	blockSize := (4097) * backend.K
 	blockNr := getRange / blockSize
 	if blockNr*blockSize != getRange {
 		blockNr++
 	}
 	data := make([]byte, 0)
 
-	cellSize := 4096 + 80
+	cellSize := 4097 + 80
 	// this is what we should get from our request
-	//containerD0 := result[0][0 : blockNr*cellSize]
+	containerD0 := result.Data[0][0 : blockNr*cellSize]
 	containerD1 := result.Data[1][0 : blockNr*cellSize]
-	containerD2 := result.Data[2][0 : blockNr*cellSize]
-	containerD3 := result.Data[3][0 : blockNr*cellSize]
 
 	containerC0 := result.Data[4][0 : blockNr*cellSize]
+	containerC1 := result.Data[5][0 : blockNr*cellSize]
 
 	for i := 0; i < blockNr; i++ {
 		var vect [][]byte
-		//subContainerD0 := containerD0[i*cellSize : cellSize]
+		subContainerD0 := containerD0[i*cellSize : (i+1)*cellSize]
 		subContainerD1 := containerD1[i*cellSize : (i+1)*cellSize]
-		subContainerD2 := containerD2[i*cellSize : (i+1)*cellSize]
-		subContainerD3 := containerD3[i*cellSize : (i+1)*cellSize]
+
 		subContainerC0 := containerC0[i*cellSize : (i+1)*cellSize]
-		// we simulate the loss of datapart 1
-		//vect = append(vect, subContainerD0)
+		subContainerC1 := containerC1[i*cellSize : (i+1)*cellSize]
+		// we simulate the loss of datapart 2 & 3
+		vect = append(vect, subContainerD0)
 		vect = append(vect, subContainerD1)
-		vect = append(vect, subContainerD2)
-		vect = append(vect, subContainerD3)
+
 		vect = append(vect, subContainerC0)
+		vect = append(vect, subContainerC1)
 
 		subdata, err := backend.Decode(vect)
 		if err != nil {
 			t.Errorf("error subdecoding %d cause=%v", i, err)
 		}
 		data = append(data, subdata.Data...)
-		data = append(data, subContainerD1[80:]...)
-		data = append(data, subContainerD2[80:]...)
-		data = append(data, subContainerD3[80:]...)
+
 		subdata.Free()
 	}
+
 	for i := 0; i < len(data)-1; i++ {
 		if data[i] != 'Z' {
 			if data[i] != data[i+1]-1 {

--- a/backend_test.go
+++ b/backend_test.go
@@ -725,17 +725,17 @@ func TestMatrixBounds(t *testing.T) {
 		expectedStart int
 		expectedEnd   int
 	}{
-		{rangeStart: 1023999, rangeEnd: 1048575, chunkUnit: DefaultChunkSize, expectedStart: 492720, expectedEnd: 524288},
+		{rangeStart: 1023999, rangeEnd: 1048575, chunkUnit: DefaultChunkSize, expectedStart: 492720, expectedEnd: 525568},
 	}
 
 	for _, param := range testParams {
 		p := param
 		testName := fmt.Sprintf("TestEMatrixBounds-%d-%d", p.rangeStart, p.rangeEnd)
 		t.Run(testName, func(t *testing.T) {
-			start, end := backend.GetRangeMatrix(p.rangeStart, p.rangeEnd, p.chunkUnit, DefaultFragSize)
-			if start != p.expectedStart || end != p.expectedEnd {
-				t.Errorf("start is %d instead of %d and end is %d instead of %d",
-					start, p.expectedStart, end, p.expectedEnd)
+			rmatrix := backend.GetRangeMatrix(p.rangeStart, p.rangeEnd, p.chunkUnit, DefaultFragSize)
+
+			if rmatrix.FragRangeStart != p.expectedStart || rmatrix.FragRangeEnd != p.expectedEnd {
+				t.Errorf("error : %+v but got %+v", p, rmatrix)
 			}
 
 		})

--- a/backend_test.go
+++ b/backend_test.go
@@ -669,6 +669,15 @@ func TestEncodeM(t *testing.T) {
 			if ok := checkData(ddata2.Data); ok == false {
 				t.Errorf("bad matrix repairing")
 			}
+
+			/*
+			 * now we will do the same but we should failed because the chunksize provided
+			 * to decode the data is not the same used by encode function
+			 */
+			_, err = backend.decodeMatrixSlow(result.Data, p[0]+1)
+			if err == nil {
+				t.Errorf("no error during decoding whereas bad params were provided")
+			}
 		})
 	}
 }

--- a/backend_test.go
+++ b/backend_test.go
@@ -507,6 +507,7 @@ func TestGC(t *testing.T) {
 			wg.Wait()
 		})
 	}
+	backend.Close()
 }
 
 func TestAvailableBackends(t *testing.T) {
@@ -533,6 +534,7 @@ func BenchmarkEncode(b *testing.B) {
 		}
 		encoded.Free()
 	}
+	backend.Close()
 }
 
 const DefaultChunkSize = 32768
@@ -562,6 +564,7 @@ func BenchmarkDecodeM(b *testing.B) {
 			b.Fatal("decoded is nil")
 		}
 	}
+	backend.Close()
 }
 
 func BenchmarkDecodeMSlow(b *testing.B) {
@@ -574,15 +577,15 @@ func BenchmarkDecodeMSlow(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		defer encoded.Free()
 
 		decoded, err := backend.decodeMatrixSlow(encoded.Data, DefaultChunkSize)
 		if err != nil {
 			b.Fatal(err)
 		}
-
-		defer decoded.Free()
+		encoded.Free()
+		decoded.Free()
 	}
+	backend.Close()
 }
 
 func BenchmarkEncodeM(b *testing.B) {
@@ -599,6 +602,7 @@ func BenchmarkEncodeM(b *testing.B) {
 		}
 		encoded.Free()
 	}
+	backend.Close()
 }
 
 func BenchmarkDecode(b *testing.B) {
@@ -617,6 +621,7 @@ func BenchmarkDecode(b *testing.B) {
 		}
 		decoded.Free()
 	}
+	backend.Close()
 }
 
 func TestEncodeM(t *testing.T) {
@@ -688,6 +693,7 @@ func TestEncodeM(t *testing.T) {
 			result.Free()
 		})
 	}
+	backend.Close()
 }
 
 // checkData reads a buffer and check that we have a round robin sequence of [A-Z] characters
@@ -795,4 +801,5 @@ func TestReconstructM(t *testing.T) {
 			}
 		})
 	}
+	backend.Close()
 }

--- a/backend_test.go
+++ b/backend_test.go
@@ -16,6 +16,8 @@ var validParams = []Params{
 	{Name: "liberasurecode_rs_vand", K: 8, M: 4},
 	{Name: "liberasurecode_rs_vand", K: 15, M: 4},
 	{Name: "isa_l_rs_vand", K: 2, M: 1},
+	{Name: "isa_l_rs_vand", K: 2, M: 1, MaxBlockSize: 1},
+	{Name: "isa_l_rs_vand", K: 2, M: 1, MaxBlockSize: maxBuffer * 2},
 	{Name: "isa_l_rs_vand", K: 10, M: 4},
 	{Name: "isa_l_rs_vand", K: 4, M: 3},
 	{Name: "isa_l_rs_vand", K: 8, M: 4},
@@ -554,7 +556,11 @@ func (d decodeTest) String() string {
 
 var decodeTests = []decodeTest{
 	{1024 * 1024, Params{Name: "isa_l_rs_vand", K: 4, M: 2, W: 8, HD: 5}},
-	{4 * 100000, Params{Name: "isa_l_rs_vand", K: 5, M: 7}},
+	{5 * 100000, Params{Name: "isa_l_rs_vand", K: 5, M: 7}},
+	// Will force an allocation of a new (dedicated) pool
+	{10000000, Params{Name: "isa_l_rs_vand", K: 2, M: 1, MaxBlockSize: 10000000 + maxBuffer}},
+	// Will force an allocation at every encoding (but should work)
+	{maxBuffer * 2, Params{Name: "isa_l_rs_vand", K: 2, M: 1, MaxBlockSize: maxBuffer / 2}},
 }
 
 func BenchmarkDecodeM(b *testing.B) {

--- a/streaming.go
+++ b/streaming.go
@@ -11,7 +11,7 @@ import (
 	"io"
 	"os"
 )
-
+// ECWriter is an implementation of Writer interface
 type ECWriter struct {
 	Backend *Backend
 	Writers []io.WriteCloser
@@ -49,6 +49,7 @@ func (shim ECWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// Close closes the writer
 func (shim ECWriter) Close() error {
 	var firstErr error
 	for _, writer := range shim.Writers {
@@ -60,6 +61,7 @@ func (shim ECWriter) Close() error {
 	return firstErr
 }
 
+// GetFileWriter returns a struct containing the backend and the associated writers
 func (backend *Backend) GetFileWriter(prefix string, perm os.FileMode) (io.WriteCloser, error) {
 	writers, err := getWriters(prefix, uint8(backend.K+backend.M), perm)
 	if err != nil {
@@ -68,6 +70,7 @@ func (backend *Backend) GetFileWriter(prefix string, perm os.FileMode) (io.Write
 	return ECWriter{backend, writers}, nil
 }
 
+// ReadFragment is a stream reader, returning a slice containing fragment with its header
 func ReadFragment(reader io.Reader) ([]byte, error) {
 	header := make([]byte, C.sizeof_struct_fragment_header_s)
 	n, err := io.ReadFull(reader, header)


### PR DESCRIPTION
EncodeM API is intented to be used when we have big part to encode and
want to add the abaility of getting and repairing only small blocks
instead of the whole chunk

For instance EncodeM(data, 4096) will create X K+N association of 4kb of
data. Thanks to that, if we only need a subset of the final data, we can
do that, and we can repair it only with 4kb block buffers